### PR TITLE
ユーザー新規登録ページのエラーハンドリング

### DIFF
--- a/app/assets/javascripts/sign-up.js
+++ b/app/assets/javascripts/sign-up.js
@@ -69,6 +69,10 @@ function input_check(){
 		$("#password_error").html(" 7文字以上 128文字以下で入力してください。");
 		$(".main__box__contents__pass__form").addClass("inp_error");
 		result = false;
+	}else if(!password.match(/^(?=.*?[a-z])(?=.*?\d)[a-z\d]/i)){
+		$("#password_error").html(" フォーマットが不適切です");
+		$(".main__box__contents__pass__form").addClass("inp_error");
+		result = false;
 	}
 
 	if(repeat == ""){

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -25,9 +25,9 @@
               必須
           = f.email_field :email, autocomplete: "email", placeholder:'PC・携帯どちらでも可',class:'main__box__contents__email__form'
           %span#email_error.error_m
-          - @user.errors.full_messages_for(:email).each do |message|
-            %span#email_error__color
-              = "この#{message}"
+            - @user.errors.full_messages_for(:email).each do |message|
+              %span#email_error__color
+                = "この#{message}"
 
         .main__box__contents__pass
           .main__box__contents__pass__top


### PR DESCRIPTION
# What
前回マージした、ユーザー新規登録ページのエラーハンドリング実装。
（新規登録機能は実装済、エラーハンドリングのみコードレビューお願いします）

sign-up.js   :New registration page Error handling
_new_registration.scss  :　Color unification
application.rb  : Convert error sentence to Japanese
ja.yml  :Japanese settings
Gemfile  : Convert error sentence to Japanese

# Why
間違ったデータが登録されないようにする為。