### PR TITLE
edit　販売手数料と利益計算

### DIFF
--- a/app/assets/javascripts/PayOff.js
+++ b/app/assets/javascripts/PayOff.js
@@ -12,4 +12,17 @@ $(function(){
     $('.product-listings-page__main__contents__price-box__form-box__lists-interests-right').html('');
     }
   });
+  $('#item_price').ready( function(){
+    var data = $('#item_price').val();
+    var profit = Math.round(data * 0.9);
+    var fee = (data - profit);
+    $('.product-listings-page__main__contents__price-box__form-box__lists-fee-right').html(fee)
+    $('.product-listings-page__main__contents__price-box__form-box__lists-fee-right').prepend('¥')
+    $('.product-listings-page__main__contents__price-box__form-box__lists-interests-right').html(profit)
+    $('.product-listings-page__main__contents__price-box__form-box__lists-interests-right').prepend('¥')
+    if(profit == '') {
+    $('.product-listings-page__main__contents__price-box__form-box__lists-fee-right').html('');
+    $('.product-listings-page__main__contents__price-box__form-box__lists-interests-right').html('');
+    }
+  });
 });


### PR DESCRIPTION
# what
商品編集画面での販売手数料と利益計算の実装。
商品出品とは異なり、読み込みと同時に算出してくれるようにPayOff.jsに設定

# why
販売手数料と利益を編集画面でも確認できるようにするため。